### PR TITLE
Add GitHub workflows to build and test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+name: build
+jobs:
+
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install libapparmor-dev
+      run: sudo apt-get install -y libapparmor-dev
+    - name: Build
+      run: |
+        make build
+    - name: Build Example Code
+      run: |
+        make example
+
+  macos:
+    runs-on: macos-latest
+    env:
+      BUILD_TAGS: "netgo"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        make build
+    - name: Build Example Code
+      run: |
+        make example

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,9 +1,8 @@
 on:
-  pull_request: {}
+  pull_request:
   push:
     branches:
     - main
-    - master
 name: Semgrep
 jobs:
   semgrep:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GO ?= go
 GCC ?= gcc
 DOCKER ?= docker
 IMAGE_TAG ?= paulinhu/go-apparmor:1
+BUILD_TAGS ?= apparmor
 
 CWD := $(realpath .)
 OUTDIR := $(CWD)/build
@@ -19,6 +20,10 @@ image:
 
 .PHONY: build
 build:
+	$(GO) build -tags $(BUILD_TAGS) ./...
+
+.PHONY: example
+example:
 	pushd example/code && \
 	$(GO) build -ldflags '$(LDFLAGS)' -o $(OUTDIR)/$(BINARY) ./main.go || \
 	popd

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ load-profile:
 	apparmor_parser -Kr $(PROFILE_PATH)
 	grep test-profile /sys/kernel/security/apparmor/profiles
 
+tidy:
+	go mod tidy
+	pushd example/code && \
+	$(GO) mod tidy || \
+	popd
+
 .PHONY: verify
 verify:
 	$(GOSEC) ./...

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ load-profile:
 	grep test-profile /sys/kernel/security/apparmor/profiles
 
 tidy:
-	go mod tidy
+	$(GO) mod tidy
 	pushd example/code && \
 	$(GO) mod tidy || \
 	popd

--- a/example/code/go.mod
+++ b/example/code/go.mod
@@ -1,14 +1,14 @@
 module github.com/pjbgf/go-apparmor/example/code
 
-go 1.17
+go 1.18
+
+replace github.com/pjbgf/go-apparmor => ../..
 
 require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/pjbgf/go-apparmor v0.0.5
 	github.com/sirupsen/logrus v1.8.1
 )
-
-replace github.com/pjbgf/go-apparmor => ../..
 
 require (
 	github.com/go-logr/logr v1.2.0 // indirect

--- a/example/code/go.mod
+++ b/example/code/go.mod
@@ -11,6 +11,6 @@ require (
 )
 
 require (
-	github.com/go-logr/logr v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 )

--- a/example/code/go.sum
+++ b/example/code/go.sum
@@ -4,10 +4,9 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
-github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -24,8 +23,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42 h1:G2DDmludOQZoWbpCr7OKDxnl478ZBGMcOhrv+ooX/Q4=
-golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pjbgf/go-apparmor
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.17
 
 require (
 	github.com/go-logr/logr v1.2.3
-	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42 h1:G2DDmludOQZoWbpCr7OKDxnl478ZBGMcOhrv+ooX/Q4=
-golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 h1:v1W7bwXHsnLLloWYTVEdvGvA7BHMeBYsPcF0GLDxIRs=
 golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 h1:v1W7bwXHsnLLloWYTVEdvGvA7BHMeBYsPcF0GLDxIRs=
-golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -1,8 +1,6 @@
 package apparmor
 
 import (
-	"runtime"
-
 	"github.com/go-logr/logr"
 )
 
@@ -26,19 +24,4 @@ type aa interface {
 
 	// LoadPolicy loads an AppArmor policy into the kernel.
 	LoadPolicy(fileName string) error
-}
-
-var goOS = func() string {
-	return runtime.GOOS
-}
-
-// NewAppArmor creates a new instance of the apparmor API.
-func NewAppArmor() aa {
-	if goOS() == "linux" {
-		return &AppArmor{
-			logger: logr.Discard(),
-		}
-	}
-
-	return &unsupported{}
 }

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && apparmor
+// +build linux,apparmor
 
 package apparmor
 
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -39,6 +40,21 @@ var (
 	aaAccessToPathDeniedErr      = errors.New("access to the required paths was denied")
 	aaFSNotFoundErr              = errors.New("appArmor filesystem mount could not be found")
 )
+
+var goOS = func() string {
+	return runtime.GOOS
+}
+
+// NewAppArmor creates a new instance of the apparmor API.
+func NewAppArmor() aa {
+	if goOS() == "linux" {
+		return &AppArmor{
+			logger: logr.Discard(),
+		}
+	}
+
+	return &unsupported{}
+}
 
 type AppArmor struct {
 	logger logr.Logger

--- a/pkg/apparmor/apparmor_test.go
+++ b/pkg/apparmor/apparmor_test.go
@@ -1,3 +1,6 @@
+//go:build linux && apparmor
+// +build linux,apparmor
+
 package apparmor
 
 import (

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux || !apparmor
+// +build !linux !apparmor
+
+package apparmor
+
+func NewAppArmor() aa {
+	return &unsupported{}
+}

--- a/pkg/hostop/container_linux.go
+++ b/pkg/hostop/container_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package hostop
 
 import (
@@ -70,10 +73,14 @@ func HostPidNamespace() (bool, error) {
 
 	if scanner.Scan() {
 		line := scanner.Text()
-		exec := strings.Split(line, " ")[0]
-		for _, hostExec := range hostIdentifierExec {
-			if exec == hostExec {
-				return true, nil
+		split := strings.Split(line, " ")
+
+		if len(split) > 0 {
+			exec := split[0]
+			for _, hostExec := range hostIdentifierExec {
+				if exec == hostExec {
+					return true, nil
+				}
 			}
 		}
 	}

--- a/pkg/hostop/mount_linux.go
+++ b/pkg/hostop/mount_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package hostop
 
 import (

--- a/pkg/hostop/mount_unsupported.go
+++ b/pkg/hostop/mount_unsupported.go
@@ -1,0 +1,23 @@
+//go:build !linux
+// +build !linux
+
+package hostop
+
+import (
+	logr "github.com/go-logr/logr"
+)
+
+type mountHostOp struct {
+}
+
+func NewMountHostOp() HostOp {
+	return &mountHostOp{}
+}
+
+func (m *mountHostOp) WithLogger(logger logr.Logger) HostOp {
+	return m
+}
+
+func (m *mountHostOp) Do(action func() error) error {
+	return nil
+}


### PR DESCRIPTION
- Updates to Go 1.18.
- Ensures go-apparmor can be built when AppArmor is not supported or within non-linux environments.