### PR TITLE
Add an option to skip the check that a container runs into the host PID namespace

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -128,7 +128,7 @@ func (a *AppArmor) LoadPolicy(fileName string) error {
 
 	err = cmd.Run()
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing profile: %w", err)
 	}
 
 	runtime.LockOSThread()

--- a/pkg/hostop/options.go
+++ b/pkg/hostop/options.go
@@ -7,6 +7,7 @@ import (
 type hostOpOpts struct {
 	logger          logr.Logger
 	insideContainer func() bool
+	hostPidCheck    func() bool
 }
 
 type HostOpOption func(*hostOpOpts)
@@ -38,5 +39,13 @@ func WithAssumeContainer() HostOpOption {
 func WithAssumeHost() HostOpOption {
 	return func(o *hostOpOpts) {
 		o.insideContainer = func() bool { return false }
+	}
+}
+
+// WithAssumeHostPidNamespace ensures that HostOp always assume that the container
+// runs into the host PID namespace.
+func WithAssumeHostPidNamespace() HostOpOption {
+	return func(o *hostOpOpts) {
+		o.hostPidCheck = func() bool { return false }
 	}
 }


### PR DESCRIPTION
The check that a container runs into the host PID namespace requires that the CONFIG_SCHED_DEBUG is enabled into the Linux kernel. There are distros which do not enable this check.

Typically is safe to assume that this check is not required when running in a Kubernetes environment.
